### PR TITLE
Added -output-separate-file flag to Save output in separate files based on root domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,39 @@ go install github.com/g0ldencybersec/gungnir/cmd/gungnir@latest
 # Options
 ```sh
 Usage of gungnir:
-  -debug    Debug CT logs to see if you are keeping up. Outputs to STDERR
-  -r        Path to the list of root domains to filter against
-  -f        Option to have Gungnir watch the roots file for updates and add them to the scan
-  -v        Output go logs (500/429 errors) to STDERR
-  -j        JSONL output cert info
+  -debug
+        Debug CT logs to see if you are keeping up
+  -f    Monitor the root domain file for updates and add the new roots to the scan
+  -j    JSONL output cert info
+  -output-separate-file
+        Save output in separate files based on root domain
+  -r string
+        Path to the list of root domains to filter against
+  -v    Output go logs (500/429 errors) to command line
 ```
 
 To run the tool, use a text file of root domains you want to monitor: `roots.txt`. Then, run the `gungnir` module:
 
 ```sh
-./gungnir -r roots.txt (filtered)
+gungnir -r roots.txt (filtered)
 - or -
-./gungnir -r roots.txt -f (filtered and following)
+gungnir -r roots.txt -f (filtered and following)
 - or -
-./gungnir (unfiltered)
+gungnir (unfiltered)
 
+```
+
+## Usage Example of `-output-separate-file`
+You can create your own bug bounty subdomains database like this https://github.com/rix4uni/BugBountyData, https://bugbountydata.netlify.app
+```
+#cat roots.txt
+microsoft.com
+zendesk.com
+
+#gungnir -r roots.txt -output-separate-file
+gungnir
+├── microsoft.com.txt
+└── zendesk.com.txt
 ```
 
 Once the tool starts and initializes, it will print domains to stdout. So feel free to pipe the output into your favorite tool!

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -3,11 +3,12 @@ package runner
 import "flag"
 
 type Options struct {
-	Verbose    bool
-	RootList   string
-	Debug      bool
-	JsonOutput bool
-	WatchFile  bool
+	Verbose            bool
+	RootList           string
+	Debug              bool
+	JsonOutput         bool
+	WatchFile          bool
+	OutputSeparateFile bool
 }
 
 func ParseOptions() *Options {
@@ -18,6 +19,7 @@ func ParseOptions() *Options {
 	flag.BoolVar(&options.Verbose, "v", false, "Output go logs (500/429 errors) to command line")
 	flag.BoolVar(&options.Debug, "debug", false, "Debug CT logs to see if you are keeping up")
 	flag.BoolVar(&options.JsonOutput, "j", false, "JSONL output cert info")
+	flag.BoolVar(&options.OutputSeparateFile, "output-separate-file", false, "Save output in separate files based on root domain")
 	flag.Parse()
 
 	return options

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,6 +21,17 @@ import (
 	"github.com/google/certificate-transparency-go/jsonclient"
 )
 
+// GetRootDomain extracts the root domain from a full domain name
+func GetRootDomain(domain string, rootDomains map[string]bool) string {
+	for root := range rootDomains {
+		if strings.HasSuffix(domain, root) {
+			return root
+		}
+	}
+	// Return the domain itself if no match is found
+	return domain
+}
+
 var getByScheme = map[string]func(*url.URL) ([]byte, error){
 	"http":  readHTTP,
 	"https": readHTTP,


### PR DESCRIPTION
## Usage Example of `-output-separate-file`
You can create your own bug bounty subdomains database like this https://github.com/rix4uni/BugBountyData, https://bugbountydata.netlify.app
```
#cat roots.txt
microsoft.com
zendesk.com

#gungnir -r roots.txt -output-separate-file
gungnir
├── microsoft.com.txt
└── zendesk.com.txt
```