### PR TITLE
Added output option for creating files per domain

### DIFF
--- a/cmd/gungnir/main.go
+++ b/cmd/gungnir/main.go
@@ -1,14 +1,20 @@
 package main
 
 import (
+	"log"
+
 	"github.com/g0ldencybersec/gungnir/pkg/runner"
 )
 
 func main() {
-	options := runner.ParseOptions()
+	options, err := runner.ParseOptions()
+	if err != nil {
+		log.Fatalf("Error parsing options: %v", err)
+	}
+
 	runner, err := runner.NewRunner(options)
 	if err != nil {
-		panic(err)
+		log.Fatalf("Error creating runner: %v", err)
 	}
 
 	runner.Run()

--- a/pkg/runner/options.go
+++ b/pkg/runner/options.go
@@ -1,6 +1,9 @@
 package runner
 
-import "flag"
+import (
+	"flag"
+	"fmt"
+)
 
 type Options struct {
 	Verbose    bool
@@ -8,17 +11,24 @@ type Options struct {
 	Debug      bool
 	JsonOutput bool
 	WatchFile  bool
+	OutputDir  string
 }
 
-func ParseOptions() *Options {
+func ParseOptions() (*Options, error) {
 	options := &Options{}
 
 	flag.StringVar(&options.RootList, "r", "", "Path to the list of root domains to filter against")
-	flag.BoolVar(&options.WatchFile, "f", false, "Monitor the root domain file for updates and add the new roots to the scan")
+	flag.BoolVar(&options.WatchFile, "f", false, "Monitor the root domain file for updates and restart the scan. requires the -r flag")
 	flag.BoolVar(&options.Verbose, "v", false, "Output go logs (500/429 errors) to command line")
 	flag.BoolVar(&options.Debug, "debug", false, "Debug CT logs to see if you are keeping up")
 	flag.BoolVar(&options.JsonOutput, "j", false, "JSONL output cert info")
+	flag.StringVar(&options.OutputDir, "o", "", "Directory to store output files (one per hostname, requires -r flag)")
 	flag.Parse()
 
-	return options
+	// Validate that output directory is only used with root list
+	if options.OutputDir != "" && options.RootList == "" {
+		return nil, fmt.Errorf("the -o flag requires the -r flag to be set")
+	}
+
+	return options, nil
 }


### PR DESCRIPTION
I added functionality and an option to output the hosts and certs to files.  This is one file per domain listed in the rootsdomain file.  The -r option is required to use the -o option as I was worried about file handles if we did this against a raw output.  This function added respects the JSONL output flag as well.  So if that is true, the output will contain the cert details as well as the hostname the cert was issued for.